### PR TITLE
switched to use nonce in miliseconds. 

### DIFF
--- a/lib/hitbtc/client.rb
+++ b/lib/hitbtc/client.rb
@@ -187,7 +187,7 @@ module Hitbtc
     end
 
     def nonce
-      Time.now.to_i.to_s
+      DateTime.now.strftime('%Q')
     end
 
     def encode_options(opts)


### PR DESCRIPTION
old one (in seconds) fails often api requests
